### PR TITLE
Include the file's directory in includePaths

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,11 @@ module.exports = function( file, opts ) {
 	function end() {
 		try {
 			opts = opts ? opts : {};
-			opts.includePaths = [path.dirname(file)];
+			var includePaths = opts.includePaths;
+			var pathToAdd = [path.dirname(file)];
+			opts.includePaths = Array.isArray(includePaths) ?
+			                    includePaths.concat(pathToAdd) :
+			                    pathToAdd;
 			this.queue( sass.renderSync( data, opts ) );
 		} catch( err ) {
 			this.emit( 'error', new Error( err ) );


### PR DESCRIPTION
When trying to render an scss file, which requires a file in the same directory, it will fail, since sass cannot find the file. Including the root file's directory in `includePaths` fixes this.

Before the following would fail:

```
// main.scss
@import "test";
```

It would yield the following error:

`Error: While reading or transforming "path/to/main.scss": source string:2: error: file to import not found or unreadable: "test"`

The usage of `includePaths` fixes this. Local file imports without manually passing includePaths, yay.
