### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/rotundasoftware/sass-css-stream",
   "dependencies": {
-    "node-sass": "~0.8.1",
-    "through": "~2.3.4"
+    "node-sass": "^2.1.x",
+    "through": "^2.3.x"
   }
 }


### PR DESCRIPTION
Updated dependency version numbers. 'node-sass' versions < 2.0 in particular are not compatible with Node 0.12.x.

See: https://github.com/sass/node-sass/issues/490#issuecomment-70388754